### PR TITLE
feat: refresh-token을 활용한 로그인 유지 기능 및 로그아웃 기능 구현

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,12 +1,36 @@
+"use client";
+
 import BottomNavBar from "@/domains/layout/components/BottomNavBar";
 import MobileTopBar from "@/domains/layout/components/MobileTopBar";
 import InitUserIdState from "@/domains/common/components/InitUserIdState";
+import { useEffect } from "react";
+import axios from "axios";
+import { userSpotifyStore } from "@/domains/common/stores/userSpotifyStore";
 
 export default function MainLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  useEffect(() => {
+    const tryRefresh = async () => {
+      const res = await fetch("/api/refresh-token", { method: "POST" });
+
+      if (res.status === 200) {
+        // 토큰 새로고침 성공했으면 사용자 정보 요청
+        const userData = await axios.post("/api/userData");
+        const { userId } = userData.data;
+
+        if (userId) {
+          userSpotifyStore.getState().setUserId(userId);
+          userSpotifyStore.getState().setIsLoggedIn(true);
+        }
+      }
+    };
+
+    tryRefresh();
+  }, []);
+
   return (
     <div className="min-h-screen relative pb-16">
       <MobileTopBar />

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -17,7 +17,6 @@ export default function MainLayout({
       const res = await fetch("/api/refresh-token", { method: "POST" });
 
       if (res.status === 200) {
-        // 토큰 새로고침 성공했으면 사용자 정보 요청
         const userData = await axios.post("/api/userData");
         const { userId } = userData.data;
 
@@ -25,6 +24,9 @@ export default function MainLayout({
           userSpotifyStore.getState().setUserId(userId);
           userSpotifyStore.getState().setIsLoggedIn(true);
         }
+      } else {
+        userSpotifyStore.getState().setUserId("");
+        userSpotifyStore.getState().setIsLoggedIn(false);
       }
     };
 

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const response = NextResponse.json({ success: true });
+
+  response.cookies.set("access_token", "", {
+    httpOnly: true,
+    secure: true,
+    path: "/",
+    maxAge: 0,
+    sameSite: "lax",
+  });
+  response.cookies.set("refresh_token", "", {
+    httpOnly: true,
+    secure: true,
+    path: "/",
+    maxAge: 0,
+    sameSite: "lax",
+  });
+
+  return response;
+}

--- a/src/app/api/refresh-token/route.ts
+++ b/src/app/api/refresh-token/route.ts
@@ -1,0 +1,69 @@
+import axios from "axios";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const cookieStore = cookies();
+  const access_token = (await cookieStore).get("access_token")?.value;
+  const refresh_token = (await cookieStore).get("refresh_token")?.value;
+
+  if (!access_token && !refresh_token) {
+    return NextResponse.json(
+      { message: "No tokens available" },
+      { status: 401 }
+    );
+  }
+
+  if (access_token && !refresh_token) {
+    return NextResponse.json({ message: "No refresh token" }, { status: 401 });
+  }
+
+  if (access_token && refresh_token) {
+    return NextResponse.json({ message: "Tokens are valid" }, { status: 200 });
+  }
+
+  try {
+    const client_id = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID!;
+    const client_secret = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_SECRET!;
+
+    const payload = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refresh_token!,
+      client_id,
+      client_secret,
+    });
+
+    const res = await axios.post(
+      "https://accounts.spotify.com/api/token",
+      payload.toString(),
+      {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      }
+    );
+
+    const { access_token: newAccessToken, expires_in } = res.data;
+
+    const response = NextResponse.json({ success: true });
+
+    response.cookies.set("access_token", newAccessToken, {
+      httpOnly: true,
+      secure: true,
+      path: "/",
+      maxAge: expires_in || 3600,
+      sameSite: "lax",
+    });
+
+    return response;
+  } catch (err: any) {
+    console.error(
+      "🔴 Refresh token failed:",
+      err.response?.data || err.message
+    );
+    return NextResponse.json(
+      { error: "Failed to refresh token" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## 📌 제목

refresh-token을 활용한 로그인 유지 기능 및 로그아웃 기능 구현

## 🧩 관련 이슈

없음.

## 🛠 변경사항 요약

access token 유효 기간이 1시간인데, 1시간 뒤에 재접속 했을 시에 refresh token을 활용하여 로그인 상태를 유지하는 기능을 구현했습니다.
그리고 로그아웃 api까지 구현하였기에 마이페이지에서 사용하시면 될 것 같습니다.

## 📷 스크린샷 (선택)

화면 변경점 없습니다.

## ⚠️ 주의깊게 봐주세요!

없음.
