### PR TITLE
feat: 곡 상세 페이지에서 플레이리스트 추가하기 기능 구현

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -21,7 +21,7 @@ export default function MainLayout({
     <div className="min-h-screen relative">
       {windowWidth && windowWidth < 768 ? <MobileTopBar /> : <DesktopTopBar />}
       <div
-        className={`w-full md:w-auto p-4 fixed left-0 top-16 overflow-y-auto overflow-x-hidden md:top-25 md:left-70 md:right-0 ${
+        className={`w-full md:w-auto p-4 fixed left-0 top-16 overflow-y-auto overflow-x-hidden md:top-25 md:left-70 md:right-0 md:pb-20 ${
           selectedTrackId ? "h-[calc(86vh-80px)] md:h-[calc(86vh-20px)] " : "h-[86vh]"
         }`}
       >

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -21,8 +21,10 @@ export default function MainLayout({
     <div className="min-h-screen relative">
       {windowWidth && windowWidth < 768 ? <MobileTopBar /> : <DesktopTopBar />}
       <div
-        className={`w-full md:w-auto p-4 fixed left-0 top-16 overflow-y-auto overflow-x-hidden md:top-25 md:left-70 md:right-0 md:pb-20 ${
-          selectedTrackId ? "h-[calc(86vh-80px)] md:h-[calc(86vh-20px)] " : "h-[86vh]"
+        className={`w-full md:w-auto p-4 fixed left-0 top-16 overflow-y-auto overflow-x-hidden md:top-25 md:left-70 md:right-0 ${
+          selectedTrackId
+            ? "h-[calc(86vh-80px)] md:h-[calc(86vh-80px)] "
+            : "h-[86vh] md:h-[calc(100vh-100px)]"
         }`}
       >
         {children}

--- a/src/domains/layout/components/SideBar.tsx
+++ b/src/domains/layout/components/SideBar.tsx
@@ -2,30 +2,25 @@
 
 import authAxios from "@/domains/common/lib/axios/authAxios";
 import { userSpotifyStore } from "@/domains/common/stores/userSpotifyStore";
+import { Playlist } from "@/domains/playlist/types/Playlist";
 import { useRouter } from "next/navigation";
 import { ReactNode, useEffect, useState } from "react";
 import { FaMusic } from "react-icons/fa";
 import { FaHome } from "react-icons/fa";
 import { FaListUl } from "react-icons/fa";
 
-type PlayListType = {
-  id: string;
-  name: string;
-  owner: {
-    id: string;
-  };
-};
-
 export default function SideBar() {
-  const [playList, setPlayList] = useState<PlayListType[]>([]);
+  const [playList, setPlayList] = useState<Playlist[]>([]);
   const isLoggedIn = userSpotifyStore((state) => state.isLoggedIn);
   const router = useRouter();
+  const userId = userSpotifyStore((state) => state.userId);
 
   useEffect(() => {
     const fetchData = async () => {
       const res = await authAxios.get("/api/playlist/getPlaylist");
-      const data = (await res.data) as PlayListType[];
-      setPlayList(data);
+      const data = res.data as Playlist[];
+      const myPlaylist = data.filter((v) => v.owner.id === userId);
+      setPlayList(myPlaylist);
     };
     if (isLoggedIn) fetchData();
   }, [isLoggedIn]);

--- a/src/domains/main/components/MyPlayList.tsx
+++ b/src/domains/main/components/MyPlayList.tsx
@@ -29,8 +29,9 @@ export default function MyPlayList({ isLoggedIn }: { isLoggedIn: boolean }) {
     if (!isLoggedIn) return;
     const fetchData = async () => {
       const res = await authAxios.get("/api/playlist/getPlaylist");
-      const data = await res.data;
-      setListData(data);
+      const data = await res.data as Playlist[];
+      const myPlaylist = data.filter((v) => v.owner.id === userId);
+      setListData(myPlaylist);
     };
     fetchData();
   }, [isLoggedIn, userId]);

--- a/src/domains/playlist/components/PlayList.tsx
+++ b/src/domains/playlist/components/PlayList.tsx
@@ -22,7 +22,7 @@ export default function PlayList({ playlists, setPlaylists, track }: Props) {
       setIsLoading(true);
       try {
         const res = await authAxios.get("/api/playlist/getPlaylist");
-        const data = await res.data;
+        const data = res.data as Playlist[];
         const myPlaylist = data.filter((v) => v.owner.id === userId);
         setPlaylists(myPlaylist);
       } catch (error) {
@@ -55,7 +55,7 @@ export default function PlayList({ playlists, setPlaylists, track }: Props) {
 
       //TODO : 신규 트랙 추가 후 플리 track 수 업데이트 미반영 오류
       const res = await authAxios.get("/api/playlist/getPlaylist");
-      const json = res.data;
+      const json = res.data as Playlist[];
       const data = json.filter((v) => v.owner.id === userId);
       setPlaylists(data);
     } catch (err) {

--- a/src/domains/playlist/types/Playlist.ts
+++ b/src/domains/playlist/types/Playlist.ts
@@ -4,6 +4,9 @@ export interface Playlist {
   images: { url: string }[];
   tracks: { total: number };
   public: boolean;
+  owner: {
+    id: string;
+  }
 }
 
 export interface AddNewPlaylistProps {

--- a/src/domains/track/components/TrackActionBtns.tsx
+++ b/src/domains/track/components/TrackActionBtns.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { FaPlay } from "react-icons/fa";
-import { HiOutlineDotsVertical } from "react-icons/hi";
 import LikedButton from "@/domains/common/components/LikedButton";
 import { useEffect, useState } from "react";
 import { userSpotifyStore } from "@/domains/common/stores/userSpotifyStore";
 import authAxios from "@/domains/common/lib/axios/authAxios";
+import { FaPlus } from "react-icons/fa";
+import PlayListModal from "@/domains/playlist/components/PlayListModal";
+import { Playlist } from "@/domains/playlist/types/Playlist";
+import AddNewPlayListModal from "@/domains/playlist/components/AddNewPlayListModal";
 
 interface TrackActionBtnsProps {
   trackId: string;
@@ -13,7 +15,11 @@ interface TrackActionBtnsProps {
 
 export default function TrackActionBtns({ trackId }: TrackActionBtnsProps) {
   const [isLiked, setIsLiked] = useState(false);
+  const [showPlayListModal, setShowPlayListModal] = useState<boolean>(false);
+  const [showAddNewPlayListModal, setShowAddNewPlayListModal] = useState(false);
+  const [playlists, setPlaylists] = useState<Playlist[]>([]);
   const isLoggedIn = userSpotifyStore((state) => state.isLoggedIn);
+
   useEffect(() => {
     const fetchLikedTracks = async () => {
       if (!trackId || !isLoggedIn) return;
@@ -32,6 +38,20 @@ export default function TrackActionBtns({ trackId }: TrackActionBtnsProps) {
 
   return (
     <div className="relative flex flex-col items-center mt-4">
+      <PlayListModal
+        showModal={showPlayListModal}
+        onClose={() => setShowPlayListModal(false)}
+        playlists={playlists}
+        setPlaylists={setPlaylists}
+        onShowNewPlaylist={() => setShowAddNewPlayListModal(true)}
+        track={"spotify:track:" + trackId}
+      />
+      <AddNewPlayListModal
+        showModal={showAddNewPlayListModal}
+        onClose={() => setShowAddNewPlayListModal(false)}
+        setPlaylists={setPlaylists}
+        track={trackId}
+      />
       <div className="flex text-(--primary-blue)">
         <LikedButton
           trackId={trackId}
@@ -39,8 +59,11 @@ export default function TrackActionBtns({ trackId }: TrackActionBtnsProps) {
           setIsLiked={setIsLiked}
           className="ml-5 mr-5"
         />
-        <FaPlay size={30} className="ml-5 mr-5" />
-        <HiOutlineDotsVertical size={30} className="ml-5 mr-5 cursor-pointer" />
+        <FaPlus
+          size={30}
+          className="ml-5 mr-5 cursor-pointer"
+          onClick={() => setShowPlayListModal(true)}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 제목

곡 상세페이지에서 해당 곡 플레이리스트에 추가할 수 있는 기능 구현

## 🧩 관련 이슈

## 🛠 변경사항 요약

곡 상세페이지에서 해당 곡 플레이리스트에 추가할 수 있는 기능 구현했습니다.

## 📷 스크린샷 (선택)

| 변경 전 | 변경 후 |
|---------|---------|
| <img width="516" height="578" alt="image" src="https://github.com/user-attachments/assets/d61160ae-2737-4c11-9b2c-c8339726fdea" /> | <img width="516" height="627" alt="image" src="https://github.com/user-attachments/assets/2fab15ba-f6fa-4a52-a9a6-41b320ba1f41" /> |

## ⚠️ 주의깊게 봐주세요!

이외에도 메인페이지에서 배포 오류로 삭제했던 코드 때문에 팔로우한 플레이리스트까지 띄워지는 것 수정했습니다.(사이드바도 포함)
